### PR TITLE
Capsule site fixes

### DIFF
--- a/_includes/card_list.html
+++ b/_includes/card_list.html
@@ -11,7 +11,7 @@
         </div>
         {% endif %}
         <a href="{{ item.url | relative_url }}">
-            <h3 class="no-break">{{ item.title }}</h3>
+            <h3>{{ item.title }}</h3>
         </a>
 
         {% if item.desc %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -55,7 +55,8 @@
   {%- endfor %}
   {% feed_meta %}
   <link rel="canonical" href="{{ page.url |  relative_url }}" />
-  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}?v={{ site.time | date: "%s" }}">
+  {% assign cacheBust = site.time | date:'?v=%s' %}
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url | append: cacheBust }}">
   {% if site.fathom_site_id %}
   <script src="https://cdn.usefathom.com/script.js" data-site="{{ site.fathom_site_id }}" defer data-cfasync="false"></script>
   {% endif %}

--- a/_sass/snailedit.scss
+++ b/_sass/snailedit.scss
@@ -564,6 +564,7 @@ article {
       position: sticky;
       align-self: start;
       top: 0.5em;
+      width: 20%;
     }
 
     .header {

--- a/_sass/snailedit.scss
+++ b/_sass/snailedit.scss
@@ -136,6 +136,13 @@ body {
   "footer";
   min-height: 100vh;
   grid-template-rows: auto 1fr auto;
+  scrollbar-color: $primary-app-color $background-color;
+  ::-webkit-scrollbar-thumb {
+    background: $primary-app-color; /* Scrollbar handle color */
+  }
+  ::-webkit-scrollbar-track {
+    background: $background-color; /* Background of the scrollbar track */
+  }
 
   > header {
     grid-area: header;

--- a/_sass/snailedit.scss
+++ b/_sass/snailedit.scss
@@ -514,6 +514,8 @@ body {
 
   @media screen and (min-width: $on-xlarge) {
     scale: 1.1;
+    padding-top: 1em;
+    padding-bottom: 1em;
   }
 }
 

--- a/snailedit-app.gemspec
+++ b/snailedit-app.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "snailedit-app"
-  spec.version       = "0.1.23"
+  spec.version       = "0.1.24"
   spec.authors       = ["Rosemary Orchard", "Snailed It Development Ltd"]
   spec.email         = ["rosemary@snailedit.dev"]
 


### PR DESCRIPTION
- CAP-804 Fix the wrapping on the card titles
- CAP-803 Make the menu always 20% width when it shows next to content
- CAP-802 Fix vertical padding on screenshots when they are made larger
- Tweak cache busting so we can reuse it in a nicer fashion
- CAP-816: try to fix the scrollbar gutter colour
